### PR TITLE
Add option to enforce umask

### DIFF
--- a/trigger/config.py
+++ b/trigger/config.py
@@ -59,6 +59,10 @@ class Configuration(object):
             'deploy.repo-name': {
                 'required': True,
             },
+            'deploy.required-umask': {
+                'required': False,
+                'default': None,
+            },
             'user.name': {
                 'required': True,
             },


### PR DESCRIPTION
When deploy.require-umask is set to an octal umask trigger will
only allow commands to be run if the umask is set to the required
umask given. This excludes the help command.
