### PR TITLE
Fix UnicodeEncodeError in git username

### DIFF
--- a/trigger/shell.py
+++ b/trigger/shell.py
@@ -107,8 +107,8 @@ class Trigger(object):
             raise TriggerError(message, 130)
         if lock_info['user'] != self.conf.config['user.name']:
             if not args.force:
-                message = ('{0} started this deployment, use --force to'
-                           ' abort that deployment.').format(lock_info['user'])
+                message = (u'{0} started this deployment, use --force to'
+                            ' abort that deployment.').format(lock_info['user'])
                 raise TriggerError(message, 132)
         if not args.noreset:
             try:


### PR DESCRIPTION
This is a partial fix. There will be more errors because the user name gets mangled while written to the lockfile and read back, but that can be worked around.
